### PR TITLE
chore: fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             asset_name: ic-wasm-macos
           - os: ubuntu-latest
             name: arm
-            artifact_name: target/arm-unknown-linux-gnueabihf/release/icx-wasm
+            artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-wasm
             asset_name: ic-wasm-arm32
 
     steps:


### PR DESCRIPTION
arm artifact name was wrong.

Previous failure:
https://github.com/dfinity/ic-wasm/actions/runs/3085617853/jobs/4989112709#step:7:8

Now success:
https://github.com/dfinity/ic-wasm/actions/runs/3085722386