### PR TITLE
put wasm-opt under a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic-wasm"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-wasm"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["DFINITY Stiftung"]
 edition = "2021"
 description = "A library for performing Wasm transformations specific to canisters running on the Internet Computer"
@@ -22,15 +22,16 @@ walrus = "0.19.0"
 candid = "0.9.0-beta.2"
 rustc-demangle = "0.1"
 thiserror = "1.0.35"
-wasm-opt = "0.112.0"
-tempfile = "3.5.0"
 
+wasm-opt = { version = "0.112.0", optional = true }
+tempfile = { version = "3.5.0", optional = true }
 anyhow = { version = "1.0.34", optional = true }
 clap = { version = "4.1", features = ["derive", "cargo"], optional = true }
 
 [features]
-default = ["exe"]
+default = ["exe", "wasm-opt"]
 exe = ["anyhow", "clap"]
+wasm-opt = ["dep:wasm-opt", "tempfile"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -72,7 +72,12 @@ fn main() -> anyhow::Result<()> {
         SubCommand::Shrink { optimize } => {
             use ic_wasm::shrink;
             match optimize {
-                Some(level) => shrink::shrink_with_wasm_opt(&mut m, level)?,
+                Some(level) => {
+                    #[cfg(not(feature = "wasm-opt"))]
+                    panic!("Please build with wasm-opt feature");
+                    #[cfg(feature = "wasm-opt")]
+                    shrink::shrink_with_wasm_opt(&mut m, level)?
+                }
                 None => shrink::shrink(&mut m),
             }
         }

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -1,8 +1,6 @@
 use crate::metadata::*;
 use crate::utils::*;
-use tempfile::NamedTempFile;
 use walrus::*;
-use wasm_opt::OptimizationOptions;
 
 pub fn shrink(m: &mut Module) {
     if is_motoko_canister(m) {
@@ -28,7 +26,10 @@ pub fn shrink(m: &mut Module) {
     passes::gc::run(m);
 }
 
+#[cfg(feature = "wasm-opt")]
 pub fn shrink_with_wasm_opt(m: &mut Module, level: &str) -> anyhow::Result<()> {
+    use tempfile::NamedTempFile;
+    use wasm_opt::OptimizationOptions;
     // recursively optimize embedded modules in Motoko actor classes
     if is_motoko_canister(m) {
         let data = get_motoko_wasm_data_sections(m);


### PR DESCRIPTION
`wasm-opt` cannot be compiled in `wasm32` target. It has to put under a feature flag.