### PR TITLE
chore: Portable linux64 builds and tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,11 @@
 name: Release
-
 on:
   push:
     tags:
       - '*'
-
 jobs:
-  publish:
-    name: Release for ${{ matrix.name }}
+  build:
+    name: Build for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,7 +13,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux64
-            artifact_name: target/release/ic-wasm
+            artifact_name: target/x86_64-unknown-linux-musl/release/ic-wasm
             asset_name: ic-wasm-linux64
           - os: macos-latest
             name: macos
@@ -25,38 +23,95 @@ jobs:
             name: arm
             artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-wasm
             asset_name: ic-wasm-arm32
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Install stable toolchain
-      if: matrix.name != 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Install stable toolchain
-      if: matrix.name == 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: arm-unknown-linux-gnueabihf
-    - name: Build
-      if: matrix.name != 'arm'
-      run: cargo build --release --locked
-    - name: Cross build
-      if: matrix.name == 'arm'
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: true
-        command: build
-        args: --target arm-unknown-linux-gnueabihf --release --locked
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.asset_name }}
-        tag: ${{ github.ref }}
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        if: matrix.name != 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install stable toolchain
+        if: matrix.name == 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: arm-unknown-linux-gnueabihf
+      - name: Build
+        if: matrix.name == 'linux64'
+        run: |
+          set -x
+          sudo apt-get update -yy
+          sudo apt-get install -yy musl musl-dev musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --locked --target x86_64-unknown-linux-musl
+      - name: Build
+        if: matrix.name == 'macos'
+        run: cargo build --release --locked
+      - name: Cross build
+        if: matrix.name == 'arm'
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target arm-unknown-linux-gnueabihf --release --locked
+      - name: 'Upload assets'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.artifact_name }}
+          retention-days: 3
+  test:
+    needs: build
+    name: Test for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            asset_name: ic-wasm-linux64
+          - os: ubuntu-20.04
+            asset_name: ic-wasm-linux64
+          - os: macos-13
+            asset_name: ic-wasm-macos
+          - os: macos-12
+            asset_name: ic-wasm-macos
+          - os: macos-11
+            asset_name: ic-wasm-macos
+    steps:
+      - name: Get executable
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Executable runs
+        run: |
+          chmod +x ic-wasm
+          ./ic-wasm --version
+  publish:
+    needs: test
+    name: Publish ${{ matrix.asset_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset_name: ic-wasm-linux64
+          - asset_name: ic-wasm-arm32
+          - asset_name: ic-wasm-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get executable
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ic-wasm
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}


### PR DESCRIPTION
# Motivation
The linux64 builds work only on the exact version of ubuntu that it was compiled on.  This is an artefact of the way `cargo build` assumes, by default, that the execution environment will have the same libc as the build environment.

# Changes
- Import the release workflow from candid and change `didc` to `ic-wasm`.  This provides:
  - Builds on the same platforms as now, but the linux64 build is with musl, so runs on other distributions.
  - Tests the Mac and Linux builds on all operating systems available on GitHub.
  - Releases if the tests pass

# Tests
None, yet.  I will force a toy release to be made and we can verify that that works as expected.