### PR TITLE
Portable build test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - '*'
     branches: # TODO: Remove before merging.
-      - portable-builds  # Pushing the feature branch should test this PR.
+      - portable-builds # Pushing the feature branch should test this PR.
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -26,32 +26,32 @@ jobs:
             artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-wasm
             asset_name: ic-wasm-arm32
     steps:
-    - uses: actions/checkout@v2
-    - name: Install stable toolchain
-      if: matrix.name != 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Install stable toolchain
-      if: matrix.name == 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: arm-unknown-linux-gnueabihf
-    - name: Build
-      if: matrix.name != 'arm'
-      run: cargo build --release --locked
-    - name: Cross build
-      if: matrix.name == 'arm'
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: true
-        command: build
-        args: --target arm-unknown-linux-gnueabihf --release --locked
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        if: matrix.name != 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install stable toolchain
+        if: matrix.name == 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: arm-unknown-linux-gnueabihf
+      - name: Build
+        if: matrix.name != 'arm'
+        run: cargo build --release --locked
+      - name: Cross build
+        if: matrix.name == 'arm'
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target arm-unknown-linux-gnueabihf --release --locked
       - name: 'Upload assets'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - '*'
-    branches: # TODO: Remove before merging.
-      - portable-build-test # Pushing the feature branch should test this PR.
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -66,16 +64,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
-            asset_name: ic-wasm-linux64
+          #- os: ubuntu-22.04
+          #  asset_name: ic-wasm-linux64
           - os: ubuntu-20.04
             asset_name: ic-wasm-linux64
           - os: macos-13
             asset_name: ic-wasm-macos
           - os: macos-12
             asset_name: ic-wasm-macos
-          - os: macos-11
-            asset_name: ic-wasm-macos
+          #- os: macos-11
+          #  asset_name: ic-wasm-macos
     steps:
       - name: Get executable
         id: download
@@ -104,7 +102,6 @@ jobs:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
-        if: 1 == 0 # TODO: Remove before merging
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ic-wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,11 @@
 name: Release
-
 on:
   push:
     tags:
       - '*'
-
 jobs:
-  publish:
-    name: Release for ${{ matrix.name }}
+  build:
+    name: Build for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,7 +13,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux64
-            artifact_name: target/release/ic-wasm
+            artifact_name: target/x86_64-unknown-linux-musl/release/ic-wasm
             asset_name: ic-wasm-linux64
           - os: macos-latest
             name: macos
@@ -25,38 +23,95 @@ jobs:
             name: arm
             artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-wasm
             asset_name: ic-wasm-arm32
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Install stable toolchain
-      if: matrix.name != 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Install stable toolchain
-      if: matrix.name == 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: arm-unknown-linux-gnueabihf
-    - name: Build
-      if: matrix.name != 'arm'
-      run: cargo build --release --locked
-    - name: Cross build
-      if: matrix.name == 'arm'
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: true
-        command: build
-        args: --target arm-unknown-linux-gnueabihf --release --locked
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.asset_name }}
-        tag: ${{ github.ref }}
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        if: matrix.name != 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install stable toolchain
+        if: matrix.name == 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: arm-unknown-linux-gnueabihf
+      - name: Build
+        if: matrix.name == 'linux64'
+        run: |
+          set -x
+          sudo apt-get update -yy
+          sudo apt-get install -yy musl musl-dev musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --locked --target x86_64-unknown-linux-musl
+      - name: Build
+        if: matrix.name == 'macos'
+        run: cargo build --release --locked
+      - name: Cross build
+        if: matrix.name == 'arm'
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target arm-unknown-linux-gnueabihf --release --locked
+      - name: 'Upload assets'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.artifact_name }}
+          retention-days: 3
+  test:
+    needs: build
+    name: Test for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            asset_name: ic-wasm-linux64
+          - os: ubuntu-20.04
+            asset_name: ic-wasm-linux64
+          - os: macos-13
+            asset_name: ic-wasm-macos
+          - os: macos-12
+            asset_name: ic-wasm-macos
+          - os: macos-11
+            asset_name: ic-wasm-macos
+    steps:
+      - name: Get executable
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Executable runs
+        run: |
+          chmod +x ic-wasm
+          ./ic-wasm --version
+  publish:
+    needs: test
+    name: Publish ${{ matrix.asset_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset_name: ic-wasm-linux64
+          - asset_name: ic-wasm-arm32
+          - asset_name: ic-wasm-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get executable
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ic-wasm
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - '*'
     branches: # TODO: Remove before merging.
-      - portable-builds # Pushing the feature branch should test this PR.
+      - portable-build-test # Pushing the feature branch should test this PR.
 jobs:
   build:
     name: Build for ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux64
-            artifact_name: target/x86_64-unknown-linux-musl/release/ic-wasm
+            artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-linux64
           - os: macos-latest
             name: macos
@@ -26,40 +26,32 @@ jobs:
             artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-wasm
             asset_name: ic-wasm-arm32
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable toolchain
-        if: matrix.name != 'arm'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install stable toolchain
-        if: matrix.name == 'arm'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: arm-unknown-linux-gnueabihf
-      - name: Build
-        if: matrix.name == 'linux64'
-        run: |
-          set -x
-          sudo apt-get update -yy
-          sudo apt-get install -yy musl musl-dev musl-tools
-          rustup target add x86_64-unknown-linux-musl
-          cargo build --release --locked --target x86_64-unknown-linux-musl
-      - name: Build
-        if: matrix.name == 'macos'
-        run: cargo build --release --locked
-      - name: Cross build
-        if: matrix.name == 'arm'
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target arm-unknown-linux-gnueabihf --release --locked
+    - uses: actions/checkout@v2
+    - name: Install stable toolchain
+      if: matrix.name != 'arm'
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Install stable toolchain
+      if: matrix.name == 'arm'
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        target: arm-unknown-linux-gnueabihf
+    - name: Build
+      if: matrix.name != 'arm'
+      run: cargo build --release --locked
+    - name: Cross build
+      if: matrix.name == 'arm'
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: --target arm-unknown-linux-gnueabihf --release --locked
       - name: 'Upload assets'
         uses: actions/upload-artifact@v3
         with:
@@ -112,7 +104,7 @@ jobs:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
-        if: 1 == 0
+        if: 1 == 0 # TODO: Remove before merging
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ic-wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - '*'
+    branches: # TODO: Remove before merging.
+      - portable-builds  # Pushing the feature branch should test this PR.
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -110,6 +112,7 @@ jobs:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
+        if: 1 == 0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ic-wasm


### PR DESCRIPTION
# Motivation
The releases of `ic-wasm` should ideally work across OS versions.  In reality there are a few gaps now:

![Screenshot from 2023-06-01 18-26-27](https://github.com/dfinity/ic-wasm/assets/5982633/c74618ed-784e-4b6b-a89d-357da2a41377)

Fixing this is a bit hard because ic-wasm is Rust together with some C++ code and getting the two to compile together in a cross platform way is non-trivial.

However we can start by testing, to see what works now and what doesn't.

# Changes
- Add tests to see on which platforms the builds work.
- Comment out the platforms that do not currently work; they can be re-enabled when the builds support them.