### PR TITLE
Build with Ubuntu 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 on:
   push:
+    branches:
+      - build-with-u20
     tags:
       - '*'
 jobs:
@@ -101,6 +103,7 @@ jobs:
         with:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release
+        if: true == false
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 on:
   push:
-    branches:
-      - build-with-u20
     tags:
       - '*'
 jobs:
@@ -103,7 +101,6 @@ jobs:
         with:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release
-        if: true == false
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          #- os: ubuntu-22.04
-          #  asset_name: ic-wasm-linux64
+          - os: ubuntu-22.04
+            asset_name: ic-wasm-linux64
           - os: ubuntu-20.04
             asset_name: ic-wasm-linux64
           - os: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             name: linux64
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-linux64


### PR DESCRIPTION
# Motivation
Building with ubuntu-latest yielded binaries that work on Ubuntu-22.04 but not on 20.04:
![Screenshot from 2023-06-01 18-26-27](https://github.com/dfinity/ic-wasm/assets/5982633/c74618ed-784e-4b6b-a89d-357da2a41377)

But building with Ubuntu 20.04 yields binaries that work with both:

![Screenshot from 2023-06-08 19-12-16](https://github.com/dfinity/ic-wasm/assets/5982633/afcb33b5-3d26-4d04-8662-c069de4b1a28)

# Changes
- Build with Ubuntu 20.04
- Test builds with both Ubuntu 20.04 and 22.04.