### PR TITLE
Support binstall for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Note:
+          # - `asset_name` is the traditional name for these releases.  It is simple to understand and keeping it preserves backwards compatibility.
+          # - `binstall_name` is the name used by `cargo binstall`.  `binstall` installs a binary, if available for the given target, else builds from source.
+          #   Building from source is time-consuming, hence the preference for `cargo binstall` over `cargo install` that always builds from source.
           - asset_name: ic-wasm-linux64
+            binstall_name: ic-wasm-x86_64-unknown-linux-gnu
           - asset_name: ic-wasm-arm32
+            binstall_name: ic-wasm-arm-unknown-linux-gnueabihf
           - asset_name: ic-wasm-macos
+            binstall_name: ic-wasm-x86_64-apple-darwin
     runs-on: ubuntu-latest
     steps:
       - name: Get executable
@@ -106,4 +113,13 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ic-wasm
           asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}
+      - name: Duplicate for binstall
+        run: cp ${{ matrix.asset_name }} ${{ matrix.binstall_name }}
+      - name: Upload binstall binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ic-wasm
+          asset_name: ${{ matrix.binstall_name }}
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,11 @@ jobs:
           # - `binstall_name` is the name used by `cargo binstall`.  `binstall` installs a binary, if available for the given target, else builds from source.
           #   Building from source is time-consuming, hence the preference for `cargo binstall` over `cargo install` that always builds from source.
           - asset_name: ic-wasm-linux64
-            binstall_name: ic-wasm-x86_64-unknown-linux-gnu
+            binstall_name: ic-wasm-x86_64-unknown-linux-gnu.tar.gz
           - asset_name: ic-wasm-arm32
-            binstall_name: ic-wasm-arm-unknown-linux-gnueabihf
+            binstall_name: ic-wasm-arm-unknown-linux-gnueabihf.tar.gz
           - asset_name: ic-wasm-macos
-            binstall_name: ic-wasm-x86_64-apple-darwin
+            binstall_name: ic-wasm-x86_64-apple-darwin.tar.gz
     runs-on: ubuntu-latest
     steps:
       - name: Get executable
@@ -114,8 +114,10 @@ jobs:
           file: ic-wasm
           asset_name: ${{ matrix.asset_name }}
           tag: ${{ github.ref }}
-      - name: Duplicate for binstall
-        run: cp ${{ matrix.asset_name }} ${{ matrix.binstall_name }}
+      - name: Bundle for binstall
+        run: |
+          cp ${{ matrix.asset_name }} ic-wasm
+          tar -cvzf ${{ matrix.binstall_name }} ic-wasm
       - name: Upload binstall binaries to release
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
# Motivation
`ic-wasm` provides pre-built wasms, which is great, but there is a standard location for pre-built cargo builds.  If we use the standard location, instead or in addition to the current  location, we can use `cargo binstall ic-wasm`.

Note: Cargo quickinstall provides ic-wasm binaries but these are built by a third party, so users depend on the honesty and competence of the third party.  The quickinstall developers are probably honest and competent, but why take the risk?

Note: I checked whether binstall supports uncompressed artefacts.  [The documentation](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md) didn't seem completely clear to me on this point so I simply tried it out.  In the test it failed to install a bare executable but successfully installed the same executable packed in a `.tar.gz`.

# Changes
- Provide binaries in a location recognised by `binstall`.
  - Note: The traditional location is preserved, as some users may be relying on that URL in their workflow.

# Request
Can we please make a release after this has been merged?  Together with #35, the installation of `ic-wasm` should be significantly easier.