### PR TITLE
Fix release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           tag: ${{ github.ref }}
       - name: Bundle for binstall
         run: |
-          cp ${{ matrix.asset_name }} ic-wasm
+          chmod +x ic-wasm
           tar -cvzf ${{ matrix.binstall_name }} ic-wasm
       - name: Upload binstall binaries to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
# Motivation
The path used when releasing binaries is no longer correct, leading to broken releases.

# Changes
- The file is already at the correct path, so remove the line of code that moves the file.  It is the move that was failing during releases.
- Made the file executable.  Previously it was executable as it had just been built.  Now it has been downloaded and needs to have the executable flag set.

# Tests
I have pushed a beta tag to this PR.
- The run has succeeded: https://github.com/dfinity/ic-wasm/actions/runs/5461986453
- The beta release has been created: https://github.com/dfinity/ic-wasm/releases/tag/0.4.0-beta.0

Cargo binstall cannot be tested until there is a proper release.  Maybe it could be tested by temporarily releasing a valid semantic version that would never be used, testing binstall, then deleting that release.  Let me try that.  Nope, that won't work.  Unfortunately I see no way of testing that other than by making a real release.