### PR TITLE
feat #51: Machine readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+- Added support for JSON output to `ic-wasm info`.
+
 ## [0.2.0] - 2022-09-21
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,8 @@ dependencies = [
  "candid",
  "clap",
  "rustc-demangle",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "walrus",
@@ -503,6 +505,12 @@ checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
@@ -739,6 +747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +785,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-wasm"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["DFINITY Stiftung"]
 edition = "2021"
 description = "A library for performing Wasm transformations specific to canisters running on the Internet Computer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ tempfile = { version = "3.5.0", optional = true }
 anyhow = { version = "1.0.34", optional = true }
 clap = { version = "4.1", features = ["derive", "cargo"], optional = true }
 
+serde = "1.0"
+serde_json = "1.0"
+
 [features]
 default = ["exe", "wasm-opt"]
 exe = ["anyhow", "clap"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,14 @@ wasm-opt = { version = "0.113.0", optional = true }
 tempfile = { version = "3.5.0", optional = true }
 anyhow = { version = "1.0.34", optional = true }
 clap = { version = "4.1", features = ["derive", "cargo"], optional = true }
-
-serde = "1.0"
-serde_json = "1.0"
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [features]
-default = ["exe", "wasm-opt"]
-exe = ["anyhow", "clap"]
+default = ["anyhow", "clap", "wasm-opt"]
+exe = ["anyhow", "clap", "serde"]
 wasm-opt = ["dep:wasm-opt", "tempfile"]
+serde = ["dep:serde", "dep:serde_json"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -99,14 +99,13 @@ fn main() -> anyhow::Result<()> {
     let mut m = ic_wasm::utils::parse_wasm_file(opts.input, keep_name_section)?;
     match &opts.subcommand {
         SubCommand::Info { json } => {
-            let info = ic_wasm::info::WasmInfo::from(&m);
-            let mut stdout = std::io::stdout();
+            let wasm_info = ic_wasm::info::WasmInfo::from(&m);
             if *json {
-                let json = serde_json::to_string_pretty(&info)
+                let json = serde_json::to_string_pretty(&wasm_info)
                     .expect("Failed to express the Wasm information as JSON.");
                 println!("{}", json);
             } else {
-                ic_wasm::info::info(&m, &mut stdout)?;
+                println!("{wasm_info}");
             }
         }
         SubCommand::Shrink { .. } => ic_wasm::shrink::shrink(&mut m),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -99,8 +99,15 @@ fn main() -> anyhow::Result<()> {
     let mut m = ic_wasm::utils::parse_wasm_file(opts.input, keep_name_section)?;
     match &opts.subcommand {
         SubCommand::Info { json } => {
+            let info = ic_wasm::info::WasmInfo::from(&m);
             let mut stdout = std::io::stdout();
-            ic_wasm::info::info(&m, &mut stdout)?;
+            if *json {
+                let json = serde_json::to_string_pretty(&info)
+                    .expect("Failed to express the Wasm information as JSON.");
+                println!("{}", json);
+            } else {
+                ic_wasm::info::info(&m, &mut stdout)?;
+            }
         }
         SubCommand::Shrink { .. } => ic_wasm::shrink::shrink(&mut m),
         #[cfg(feature = "wasm-opt")]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -105,7 +105,7 @@ fn main() -> anyhow::Result<()> {
                     .expect("Failed to express the Wasm information as JSON.");
                 println!("{}", json);
             } else {
-                println!("{wasm_info}");
+                print!("{wasm_info}");
             }
         }
         SubCommand::Shrink { .. } => ic_wasm::shrink::shrink(&mut m),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -47,7 +47,11 @@ enum SubCommand {
         playground_backend_redirect: Option<candid::Principal>,
     },
     /// List information about the Wasm canister
-    Info,
+    Info {
+        /// Format the output as JSON
+        #[clap(short, long)]
+        json: bool,
+    },
     /// Remove unused functions and debug info
     Shrink {
         #[clap(short, long)]
@@ -94,7 +98,7 @@ fn main() -> anyhow::Result<()> {
     };
     let mut m = ic_wasm::utils::parse_wasm_file(opts.input, keep_name_section)?;
     match &opts.subcommand {
-        SubCommand::Info => {
+        SubCommand::Info { json } => {
             let mut stdout = std::io::stdout();
             ic_wasm::info::info(&m, &mut stdout)?;
         }

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::io::Write;
 use walrus::{ExportItem, Module};
 
@@ -37,6 +38,29 @@ impl From<&Module> for LanguageSpecificInfo {
             return LanguageSpecificInfo::Motoko { embedded_wasm };
         }
         LanguageSpecificInfo::Unknown
+    }
+}
+
+impl fmt::Display for WasmInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.language)
+    }
+}
+
+impl fmt::Display for LanguageSpecificInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LanguageSpecificInfo::Motoko { embedded_wasm } => {
+                writeln!(f, "This is a Motoko canister")?;
+                for (_, wasm_info) in embedded_wasm {
+                    writeln!(f, "--- Start decoding an embedded Wasm ---")?;
+                    write!(f, "{}", wasm_info)?;
+                    writeln!(f, "--- End of decoding ---")?;
+                }
+                writeln!(f)
+            }
+            LanguageSpecificInfo::Unknown => Ok(()),
+        }
     }
 }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,12 +1,14 @@
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::io::Write;
 use walrus::{ExportItem, Module};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{utils::*, Error};
 
 /// External information about a Wasm, such as API methods.
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WasmInfo {
     language: LanguageSpecificInfo,
     number_of_types: usize,
@@ -22,7 +24,7 @@ pub struct WasmInfo {
 }
 
 /// External information that is specific to one language
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LanguageSpecificInfo {
     Motoko {
         embedded_wasm: Vec<(String, WasmInfo)>,
@@ -31,14 +33,14 @@ pub enum LanguageSpecificInfo {
 }
 
 /// Information about an exported method.
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExportedMethodInfo {
     name: String,
     internal_name: String,
 }
 
 /// Statistics about a custom section.
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CustomSectionInfo {
     name: String,
     size: usize,

--- a/src/info.rs
+++ b/src/info.rs
@@ -17,6 +17,7 @@ pub struct WasmInfo {
     number_of_callbacks: usize,
     start_function: Option<String>,
     exported_methods: Vec<(String, String)>,
+    imported_ic0_system_api: Vec<String>,
 }
 
 /// External information that is specific to one language
@@ -51,6 +52,12 @@ impl From<&Module> for WasmInfo {
                     ExportItem::Function(id) => Some((e.name.clone(), get_func_name(m, id))),
                     _ => None,
                 })
+                .collect(),
+            imported_ic0_system_api: m
+                .imports
+                .iter()
+                .filter(|i| i.module == "ic0")
+                .map(|i| i.name.clone())
                 .collect(),
         }
     }
@@ -100,6 +107,9 @@ impl fmt::Display for WasmInfo {
             })
             .collect();
         writeln!(f, "Exported methods: {exports:#?}")?;
+        writeln!(f)?;
+        writeln!(f, "Imported IC0 System API: {:#?}", self.imported_ic0_system_api)?;
+    
         Ok(())
     }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -10,6 +10,9 @@ use crate::{utils::*, Error};
 pub struct WasmInfo {
     language: LanguageSpecificInfo,
     number_of_types: usize,
+    number_of_globals: usize,
+    number_of_data_sections: usize,
+    size_of_data_sections: usize,
 }
 
 /// External information that is specific to one language
@@ -23,9 +26,16 @@ pub enum LanguageSpecificInfo {
 
 impl From<&Module> for WasmInfo {
     fn from(m: &Module) -> WasmInfo {
+        let (number_of_data_sections, size_of_data_sections) = m
+            .data
+            .iter()
+            .fold((0, 0), |(count, size), d| (count + 1, size + d.value.len()));
         WasmInfo {
             language: LanguageSpecificInfo::from(m),
             number_of_types: m.types.iter().count(),
+            number_of_globals: m.globals.iter().count(),
+            number_of_data_sections,
+            size_of_data_sections,
         }
     }
 }
@@ -46,7 +56,19 @@ impl From<&Module> for LanguageSpecificInfo {
 impl fmt::Display for WasmInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.language)?;
-        writeln!(f, "Number of types: {}", self.number_of_types)
+        writeln!(f, "Number of types: {}", self.number_of_types)?;
+        writeln!(f, "Number of globals: {}", self.number_of_globals)?;
+        writeln!(
+            f,
+            "Number of data sections: {}",
+            self.number_of_data_sections
+        )?;
+        writeln!(
+            f,
+            "Size of data sections: {} bytes",
+            self.size_of_data_sections
+        )?;
+        writeln!(f)
     }
 }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -160,62 +160,6 @@ impl fmt::Display for LanguageSpecificInfo {
 
 /// Print general summary of the Wasm module
 pub fn info(m: &Module, output: &mut dyn Write) -> Result<(), Error> {
-    if is_motoko_canister(m) {
-        writeln!(output, "This is a Motoko canister")?;
-        for (_, module) in get_motoko_wasm_data_sections(m) {
-            writeln!(output, "--- Start decoding an embedded Wasm ---")?;
-            info(&module, output)?;
-            writeln!(output, "--- End of decoding ---")?;
-        }
-        writeln!(output)?;
-    }
-    writeln!(output, "Number of types: {}", m.types.iter().count())?;
-    writeln!(output, "Number of globals: {}", m.globals.iter().count())?;
-    writeln!(output)?;
-    let (data, data_size) = m
-        .data
-        .iter()
-        .fold((0, 0), |(count, size), d| (count + 1, size + d.value.len()));
-    writeln!(output, "Number of data sections: {data}")?;
-    writeln!(output, "Size of data sections: {data_size} bytes")?;
-    writeln!(output)?;
-    writeln!(output, "Number of functions: {}", m.funcs.iter().count())?;
-    writeln!(output, "Number of callbacks: {}", m.elements.iter().count())?;
-    writeln!(
-        output,
-        "Start function: {:?}",
-        m.start.map(|id| get_func_name(m, id))
-    )?;
-    let exports: Vec<_> = m
-        .exports
-        .iter()
-        .filter_map(|e| match e.item {
-            ExportItem::Function(id) => {
-                let name = get_func_name(m, id);
-                if e.name == name {
-                    Some(e.name.clone())
-                } else {
-                    Some(format!("{} ({})", e.name, name))
-                }
-            }
-            _ => None,
-        })
-        .collect();
-    writeln!(output, "Exported methods: {exports:#?}")?;
-    writeln!(output)?;
-    let imports: Vec<&str> = m
-        .imports
-        .iter()
-        .filter(|i| i.module == "ic0")
-        .map(|i| i.name.as_ref())
-        .collect();
-    writeln!(output, "Imported IC0 System API: {imports:#?}")?;
-    writeln!(output)?;
-    let customs: Vec<_> = m
-        .customs
-        .iter()
-        .map(|(_, s)| format!("{} ({} bytes)", s.name(), s.data(&Default::default()).len()))
-        .collect();
-    writeln!(output, "Custom sections with size: {customs:#?}")?;
+    write!(output, "{}", WasmInfo::from(m))?;
     Ok(())
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -9,6 +9,7 @@ use crate::{utils::*, Error};
 #[derive(Serialize, Deserialize)]
 pub struct WasmInfo {
     language: LanguageSpecificInfo,
+    number_of_types: usize,
 }
 
 /// External information that is specific to one language
@@ -24,6 +25,7 @@ impl From<&Module> for WasmInfo {
     fn from(m: &Module) -> WasmInfo {
         WasmInfo {
             language: LanguageSpecificInfo::from(m),
+            number_of_types: m.types.iter().count(),
         }
     }
 }
@@ -43,7 +45,8 @@ impl From<&Module> for LanguageSpecificInfo {
 
 impl fmt::Display for WasmInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.language)
+        write!(f, "{}", self.language)?;
+        writeln!(f, "Number of types: {}", self.number_of_types)
     }
 }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -13,6 +13,8 @@ pub struct WasmInfo {
     number_of_globals: usize,
     number_of_data_sections: usize,
     size_of_data_sections: usize,
+    number_of_functions: usize,
+    number_of_callbacks: usize,
 }
 
 /// External information that is specific to one language
@@ -36,6 +38,8 @@ impl From<&Module> for WasmInfo {
             number_of_globals: m.globals.iter().count(),
             number_of_data_sections,
             size_of_data_sections,
+            number_of_functions: m.funcs.iter().count(),
+            number_of_callbacks: m.elements.iter().count(),
         }
     }
 }
@@ -68,7 +72,9 @@ impl fmt::Display for WasmInfo {
             "Size of data sections: {} bytes",
             self.size_of_data_sections
         )?;
-        writeln!(f)
+        writeln!(f)?;
+        writeln!(f, "Number of functions: {}", self.number_of_functions)?;
+        writeln!(f, "Number of callbacks: {}", self.number_of_callbacks)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -216,6 +216,49 @@ Custom sections with size: []
 }
 
 #[test]
+fn json_info() {
+    let expected = r#"{
+  "language": "Unknown",
+  "number_of_types": 6,
+  "number_of_globals": 1,
+  "number_of_data_sections": 3,
+  "size_of_data_sections": 35,
+  "number_of_functions": 9,
+  "number_of_callbacks": 0,
+  "start_function": null,
+  "exported_methods": [
+    {
+      "name": "canister_query get",
+      "internal_name": "func_5"
+    },
+    {
+      "name": "canister_update inc",
+      "internal_name": "func_6"
+    },
+    {
+      "name": "canister_update set",
+      "internal_name": "func_7"
+    }
+  ],
+  "imported_ic0_system_api": [
+    "msg_reply",
+    "msg_reply_data_append",
+    "msg_arg_data_size",
+    "msg_arg_data_copy",
+    "trap"
+  ],
+  "custom_sections": []
+}
+"#;
+    wasm_input("wat.wasm", false)
+        .arg("info")
+        .arg("--json")
+        .assert()
+        .stdout(expected)
+        .success();
+}
+
+#[test]
 fn metadata() {
     // List metadata
     wasm_input("motoko.wasm", false)


### PR DESCRIPTION
# Motivation
The output of `ic-wasm info` is useful but not reliably machine readable.  See #51 for more details.

# Changes
- Add a `--json` flag to `ic-wasm info`.
- Define a structure for the Wasm info and define Display and JSON Serialize traits on that structure.
  - The Display output matches the existing output exactly.
  - The JSON output provides the same data but in machine readable format.

# Tests
- The existing test for human readable output passes with no changes.
- A similar test has been added for JSON output.