### PR TITLE
remove arm32 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -19,37 +20,16 @@ jobs:
             name: macos
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-macos
-          - os: ubuntu-latest
-            name: arm
-            artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-wasm
-            asset_name: ic-wasm-arm32
     steps:
       - uses: actions/checkout@v2
       - name: Install stable toolchain
-        if: matrix.name != 'arm'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Install stable toolchain
-        if: matrix.name == 'arm'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: arm-unknown-linux-gnueabihf
       - name: Build
-        if: matrix.name != 'arm'
         run: cargo build --release --locked
-      - name: Cross build
-        if: matrix.name == 'arm'
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target arm-unknown-linux-gnueabihf --release --locked
       - name: 'Upload assets'
         uses: actions/upload-artifact@v3
         with:
@@ -97,8 +77,6 @@ jobs:
           #   Building from source is time-consuming, hence the preference for `cargo binstall` over `cargo install` that always builds from source.
           - asset_name: ic-wasm-linux64
             binstall_name: ic-wasm-x86_64-unknown-linux-gnu.tar.gz
-          - asset_name: ic-wasm-arm32
-            binstall_name: ic-wasm-arm-unknown-linux-gnueabihf.tar.gz
           - asset_name: ic-wasm-macos
             binstall_name: ic-wasm-x86_64-apple-darwin.tar.gz
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
             name: linux64
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-linux64
-          - os: macos-latest
+          - os: macos-12
             name: macos
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
 jobs:
   build:
     name: Build for ${{ matrix.name }}


### PR DESCRIPTION
`wasm-opt` fails to cross build in arm32. The usage of arm32 is low anyway.