### PR TITLE
chore!: upgrade walrus to support memory64 and release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.8.0]
+
+* Upgrade dependency walrus.
+
 ## [0.7.3]
 
 * Enable WebAssembly SIMD in `optimize` subcommand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0]
 
 * Upgrade dependency walrus.
+  * This enables ic-wasm to process memory64 Wasm modules.
 
 ## [0.7.3]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -449,6 +455,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -523,6 +530,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -771,6 +789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7"
+checksum = "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1015,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.29.0"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
 ]
@@ -1064,9 +1088,17 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.80.2"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "semver",
+ "serde",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic-wasm"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-wasm"
-version = "0.7.3"
+version = "0.8.0"
 authors = ["DFINITY Stiftung"]
 edition = "2021"
 description = "A library for performing Wasm transformations specific to canisters running on the Internet Computer"
@@ -18,7 +18,9 @@ path = "src/bin/main.rs"
 required-features = ["exe"]
 
 [dependencies]
-walrus = "0.21.1"
+# Major version bump of walrus should result in a major version bump of ic-wasm.
+# Because we expose walrus types in ic-wasm public API.
+walrus = "0.21.1" 
 candid = "0.10"
 rustc-demangle = "0.1"
 thiserror = "1.0.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/main.rs"
 required-features = ["exe"]
 
 [dependencies]
-walrus = "0.20.1"
+walrus = "0.21.1"
 candid = "0.10"
 rustc-demangle = "0.1"
 thiserror = "1.0.35"

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -69,21 +69,21 @@ pub fn instrument(m: &mut Module, config: Config) -> Result<(), String> {
     }
     let is_partial_tracing = !trace_only_ids.is_empty();
     let func_cost = FunctionCost::new(m);
-    let total_counter = m
-        .globals
-        .add_local(ValType::I64, true, InitExpr::Value(Value::I64(0)));
+    let total_counter =
+        m.globals
+            .add_local(ValType::I64, true, false, ConstExpr::Value(Value::I64(0)));
     let log_size = m
         .globals
-        .add_local(ValType::I32, true, InitExpr::Value(Value::I32(0)));
+        .add_local(ValType::I32, true, false, ConstExpr::Value(Value::I32(0)));
     let page_size = m
         .globals
-        .add_local(ValType::I32, true, InitExpr::Value(Value::I32(0)));
+        .add_local(ValType::I32, true, false, ConstExpr::Value(Value::I32(0)));
     let is_init = m
         .globals
-        .add_local(ValType::I32, true, InitExpr::Value(Value::I32(1)));
+        .add_local(ValType::I32, true, false, ConstExpr::Value(Value::I32(1)));
     let is_entry = m
         .globals
-        .add_local(ValType::I32, true, InitExpr::Value(Value::I32(0)));
+        .add_local(ValType::I32, true, false, ConstExpr::Value(Value::I32(0)));
     let opt_init = if is_partial_tracing {
         Some(is_init)
     } else {


### PR DESCRIPTION
The recent walrus [0.21.1](https://github.com/rustwasm/walrus/releases/tag/0.21.1) release got the support for memory64.

I will release ic-wasm 0.8.0 if this PR got approved.