### PR TITLE
Correct the value of `GZIPPED_WASM_MAGIC_BYTES`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use walrus::*;
 
 pub const WASM_MAGIC_BYTES: &[u8] = &[0, 97, 115, 109];
 
-pub const GZIPPED_WASM_MAGIC_BYTES: &[u8] = &[31, 139, 8, 0];
+pub const GZIPPED_WASM_MAGIC_BYTES: &[u8] = &[31, 139, 8];
 
 fn wasm_parser_config(keep_name_section: bool) -> ModuleConfig {
     let mut config = walrus::ModuleConfig::new();


### PR DESCRIPTION
This PR fixes the value of `GZIPPED_WASM_MAGIC_BYTES` to correspond to the Gzip standard (https://datatracker.ietf.org/doc/html/rfc1952.html) which permits values other than `0` in the 4th byte of the format header.