### PR TITLE
chore: fix release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,6 @@ jobs:
             asset_name: ic-wasm-macos
     steps:
       - uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - name: Build
         run: cargo build --release --locked
       - name: 'Upload assets'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-macos
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: 'Upload assets'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.artifact_name }}
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Get executable
         id: download
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
       - name: Executable runs
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get executable
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
       - name: Upload binaries to release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
     - name: Cache cargo build
       uses: actions/cache@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.8.5] - 2024-09-05
+
+* Fix http_request redirect.
+
 ## [0.8.4] - 2024-09-05
 
 * Add `keep_name_section` option to the `metadata` subcommand.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
The release CI failed: https://github.com/dfinity/ic-wasm/actions/runs/11016404861

The different version of upload/download-artifact actions might be the cause.

I'll trigger another run once this PR is merged.