### PR TITLE
fix: Feature wasm-opt

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -23,7 +23,7 @@ jobs:
           cp ./ic-repl-linux64 /usr/local/bin/ic-repl
           chmod a+x /usr/local/bin/ic-repl
           rustup target add wasm32-unknown-unknown
-      - name: Check compilation without default features for wasm32-unknown-unknown target (needed for playground)
+      - name: Check compilation without default features for wasm32-unknown-unknown target (needed for motoko-playground)
         run: |
           cargo build --no-default-features --target wasm32-unknown-unknown
       - name: Start replica

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,6 +22,7 @@ jobs:
           wget https://github.com/chenyan2002/ic-repl/releases/download/$IC_REPL_VERSION/ic-repl-linux64
           cp ./ic-repl-linux64 /usr/local/bin/ic-repl
           chmod a+x /usr/local/bin/ic-repl
+          rustup target add wasm32-unknown-unknown
       - name: Check compilation without default features for wasm32-unknown-unknown target (needed for playground)
         run: |
           cargo build --no-default-features --target wasm32-unknown-unknown

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,6 +22,9 @@ jobs:
           wget https://github.com/chenyan2002/ic-repl/releases/download/$IC_REPL_VERSION/ic-repl-linux64
           cp ./ic-repl-linux64 /usr/local/bin/ic-repl
           chmod a+x /usr/local/bin/ic-repl
+      - name: Check compilation without default features for wasm32-unknown-unknown target (needed for playground)
+        run: |
+          cargo build --no-default-features --target wasm32-unknown-unknown
       - name: Start replica
         run: |
           echo "{}" > dfx.json
@@ -33,4 +36,4 @@ jobs:
       - name: stop dfx
         run: |
           echo "dfx stop"
-          dfx stop  
+          dfx stop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.9.5] - 2025-01-28
+
+* Fix compilation without default features.
+
 ## [0.9.4] - 2025-01-27
 
 * Allow `sign_with_schnorr` in `limit_resource`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic-wasm"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-wasm"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["DFINITY Stiftung"]
 edition = "2021"
 description = "A library for performing Wasm transformations specific to canisters running on the Internet Computer"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{self, Read};
 use walrus::*;
+#[cfg(feature = "wasm-opt")]
 use wasm_opt::Feature;
 use wasmparser::{Validator, WasmFeaturesInflated};
 
@@ -14,6 +15,7 @@ pub const GZIPPED_WASM_MAGIC_BYTES: &[u8] = &[31, 139, 8];
 // The feature set should be align with IC `wasmtime` validation config:
 // https://github.com/dfinity/ic/blob/6a6470d705a0f36fb94743b12892280409f85688/rs/embedders/src/wasm_utils/validation.rs#L1385
 // Since we use both wasm_opt::Feature and wasmparse::WasmFeature, we have to define the config/features for both.
+#[cfg(feature = "wasm-opt")]
 pub const IC_ENABLED_WASM_FEATURES: [Feature; 7] = [
     Feature::MutableGlobals,
     Feature::TruncSat,


### PR DESCRIPTION
With no default features, ic-wasm should be buildable (for the `wasm32-unknown-unknown` target, used in the motoko playground). Currently, the use of `wasm_opt::Feature` prevents a build without the `wasm_opt` feature enabled. 