### PR TITLE
feat: add option to filter cycles transfer

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -42,10 +42,10 @@ enum SubCommand {
     },
     /// Limit resource usage
     Resource {
-        /// Remove ic0.call_cycles_add[128] system API calls
+        /// Remove `ic0.call_cycles_add[128]` system API calls
         #[clap(short, long)]
         remove_cycles_transfer: bool,
-        /// Filter ic0.call_cycles_add[128] system API calls
+        /// Filter `ic0.call_cycles_add[128]` system API calls
         #[clap(short, long, conflicts_with_all = &["remove_cycles_transfer", "playground_backend_redirect"])]
         filter_cycles_transfer: bool,
         /// Allocate at most specified amount of memory pages for Wasm heap memory

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -42,9 +42,12 @@ enum SubCommand {
     },
     /// Limit resource usage
     Resource {
-        /// Remove cycles_add system API call
+        /// Remove ic0.call_cycles_add[128] system API calls
         #[clap(short, long)]
         remove_cycles_transfer: bool,
+        /// Filter ic0.call_cycles_add[128] system API calls
+        #[clap(short, long, conflicts_with_all = &["remove_cycles_transfer", "playground_backend_redirect"])]
+        filter_cycles_transfer: bool,
         /// Allocate at most specified amount of memory pages for Wasm heap memory
         #[clap(short('m'), long)]
         limit_heap_memory_page: Option<u32>,
@@ -152,6 +155,7 @@ fn main() -> anyhow::Result<()> {
         }
         SubCommand::Resource {
             remove_cycles_transfer,
+            filter_cycles_transfer,
             limit_heap_memory_page,
             limit_stable_memory_page,
             playground_backend_redirect,
@@ -159,6 +163,7 @@ fn main() -> anyhow::Result<()> {
             use ic_wasm::limit_resource::{limit_resource, Config};
             let config = Config {
                 remove_cycles_add: *remove_cycles_transfer,
+                filter_cycles_add: *filter_cycles_transfer,
                 limit_heap_memory_page: *limit_heap_memory_page,
                 limit_stable_memory_page: *limit_stable_memory_page,
                 playground_canister_id: *playground_backend_redirect,

--- a/src/limit_resource.rs
+++ b/src/limit_resource.rs
@@ -56,7 +56,7 @@ pub fn limit_resource(m: &mut Module, config: &Config) {
         let global_id = m.globals.add_local(
             ValType::I32,
             true,  // mutable
-            false, // shared
+            false, // shared (not supported yet)
             ConstExpr::Value(Value::I32(0)),
         );
         // Instrument `ic0.call_cycles_add[128]` to respect the value of the private global.

--- a/src/limit_resource.rs
+++ b/src/limit_resource.rs
@@ -170,7 +170,7 @@ fn make_filter_cycles_add(
                 then.local_get(amount).drop(); // no-op
             },
             |otherwise| {
-                otherwise.local_get(amount).call(old_cycles_add); // call ic0.call_cycles_add
+                otherwise.local_get(amount).call(old_cycles_add); // call `ic0.call_cycles_add`
             },
         );
         let new_cycles_add = builder.finish(vec![amount], &mut m.funcs);
@@ -214,7 +214,7 @@ fn make_filter_cycles_add128(m: &mut Module, replacer: &mut Replacer, global_id:
                 otherwise
                     .local_get(high)
                     .local_get(low)
-                    .call(old_cycles_add128); // call ic0.call_cycles_add128
+                    .call(old_cycles_add128); // call `ic0.call_cycles_add128`
             },
         );
         let new_cycles_add128 = builder.finish(vec![high, low], &mut m.funcs);
@@ -767,11 +767,11 @@ fn make_filter_call_new(
             .if_else(
                 None,
                 |block| {
-                    // set global to 0 => allow ic0.call_cycles_add[128]
+                    // set global to 0 => allow `ic0.call_cycles_add[128]`
                     block.i32_const(0).global_set(global_id);
                 },
                 |block| {
-                    // set global to 1 => filter ic0.call_cycles_add[128]
+                    // set global to 1 => filter `ic0.call_cycles_add[128]`
                     block.i32_const(1).global_set(global_id);
                 },
             )

--- a/src/limit_resource.rs
+++ b/src/limit_resource.rs
@@ -219,7 +219,7 @@ fn make_filter_cycles_add128(m: &mut Module, replacer: &mut Replacer, global_id:
 }
 
 fn make_cycles_burn128(m: &mut Module, replacer: &mut Replacer, wasm64: bool) {
-    if let Some(older_cycles_burn128) = get_ic_func_id(m, "call_cycles_burn128") {
+    if let Some(older_cycles_burn128) = get_ic_func_id(m, "cycles_burn128") {
         let dst_type = match wasm64 {
             true => ValType::I64,
             false => ValType::I32,

--- a/src/limit_resource.rs
+++ b/src/limit_resource.rs
@@ -746,8 +746,9 @@ fn make_filter_call_new(
                     })
                     .local_get(not_allowed_canister)
                     .br_if(checks_id); // we already know that callee is not allowed => no need to check further
-                                       // Callee is an allowed canister => check if method name is not forbidden
-                                       // no match (i.e., method name not in `forbidden_function_names`) => `allow_cycles` set to 1
+
+                // Callee is an allowed canister => check if method name is not forbidden
+                // no match (i.e., method name not in `forbidden_function_names`) => `allow_cycles` set to 1
                 check_list(
                     memory,
                     checks,

--- a/src/limit_resource.rs
+++ b/src/limit_resource.rs
@@ -705,7 +705,7 @@ fn make_filter_call_new(
             Principal::from_slice(&[]),
             Principal::from_text("7hfb6-caaaa-aaaar-qadga-cai").unwrap(),
         ];
-        let forbidden_function_names = ["deposit_cycles"];
+        let forbidden_function_names = ["create_canister", "deposit_cycles"];
 
         let mut builder = FunctionBuilder::new(
             &mut m.types,

--- a/src/limit_resource.rs
+++ b/src/limit_resource.rs
@@ -701,6 +701,9 @@ fn make_filter_call_new(
         let not_allowed_canister = m.locals.add(ValType::I32);
         let allow_cycles = m.locals.add(ValType::I32);
 
+        // Cycles transfer is only allowed if
+        // - the callee is the management canister or `7hfb6-caaaa-aaaar-qadga-cai` (EVM RPC Canister);
+        // - *and* the method name is *neither* `create_canister` *nor* `deposit_cycles`.
         let allowed_canisters = [
             Principal::from_slice(&[]),
             Principal::from_text("7hfb6-caaaa-aaaar-qadga-cai").unwrap(),


### PR DESCRIPTION
This PR adds an option to "filter" cycles transfer performed by a canister:
- turn all `ic0.call_cycles_add` and `ic0.call_cycles_add128` calls into no-op if the corresponding `ic0.call_new` (preceding the invokation of `ic0.call_cycles_add` or `ic0.call_cycles_add128`) is not whitelisted;
- turn all `ic0.cycles_burn128` calls into no-op.

Cycles transfer is only allowed if
- the callee is the management canister or `7hfb6-caaaa-aaaar-qadga-cai` (EVM RPC Canister);
- *and* the method name is *neither* `create_canister` *nor* `deposit_cycles`.

Example usage:
```
ic-wasm input.wasm -o output.wasm resource --filter-cycles-transfer
```

This PR has been manually tested on a canister calling the `http_request` endpoint on the management canister (allowed), the `deposit_cycles` endpoint on the management canister (not allowed), and a `credit_cycles` endpoint on a third-party canister (not allowed).