### PR TITLE
ci: update runner images in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "*"
+  pull_request:
+
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -104,6 +106,8 @@ jobs:
           ./ic-wasm --version
 
   publish:
+    # Check if the workflow was triggered by a tag
+    if: startsWith(github.ref, 'refs/tags/')
     needs: test
     name: Publish ${{ matrix.asset_name }}
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # The runner images are chosen to be one major version behind the latest.
+      # The macOS runner should be x86_64 so that the binary can run on both Intel and Apple Silicon Macs.
+      # For example, as of Sep 2025
+      # - The latest Ubuntu is 24.04, so we use ubuntu-22.04
+      # - The latest macOS is 15, so we use macos-14-large
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: linux64
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-linux64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: linux-musl
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-linux-musl
-          - os: macos-13
+          - os: macos-14-large # x86_64 build that can run on both Intel and Apple Silicon Macs
             name: macos
             artifact_name: target/release/ic-wasm
             asset_name: ic-wasm-macos
@@ -56,17 +61,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # The binaries built in the `build` job are tested on:
+      # - Ubuntu: latest and one major version behind latest.
+      # - macOS: latest and one major version behind latest. Both x86_64 and arm64 runner images.
       matrix:
         include:
-          - os: ubuntu-22.04
-            asset_name: ic-wasm-linux64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             asset_name: ic-wasm-linux64
           - os: ubuntu-22.04
+            asset_name: ic-wasm-linux64
+          - os: ubuntu-latest
             asset_name: ic-wasm-linux-musl
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             asset_name: ic-wasm-linux-musl
-          - os: macos-13
+          - os: macos-latest-large
+            asset_name: ic-wasm-macos
+          - os: macos-latest
+            asset_name: ic-wasm-macos
+          - os: macos-14-large
             asset_name: ic-wasm-macos
           - os: macos-14
             asset_name: ic-wasm-macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 jobs:
   build:
     name: Build for ${{ matrix.name }}
@@ -48,7 +48,7 @@ jobs:
             cargo build --release --locked
           '
 
-      - name: 'Upload assets'
+      - name: "Upload assets"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,37 +9,37 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Cache cargo build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/*.rs', '**/Cargo.toml') }}
-    - name: Cache cargo binaries
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/bin
-        key: cargo-bin-${{ runner.os }}-v1
-    - name: Install cargo-sort if needed
-      run: |
-        if ! command -v cargo-sort &> /dev/null; then
-          echo "Installing cargo-sort..."
-          cargo install cargo-sort
-        else
-          echo "cargo-sort already installed from cache."
-        fi
-    - name: cargo sort
-      run: cargo sort --check
-    - name: Build
-      run: cargo build --features "serde"
-    - name: Run tests
-      run: cargo test -- --test-threads=1
-    - name: fmt
-      run: cargo fmt -v -- --check
-    - name: lint
-      run: cargo clippy --tests -- -D clippy::all
-    - name: doc
-      run: cargo doc
+      - uses: actions/checkout@v4
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/*.rs', '**/Cargo.toml') }}
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-v1
+      - name: Install cargo-sort if needed
+        run: |
+          if ! command -v cargo-sort &> /dev/null; then
+            echo "Installing cargo-sort..."
+            cargo install cargo-sort
+          else
+            echo "cargo-sort already installed from cache."
+          fi
+      - name: cargo sort
+        run: cargo sort --check
+      - name: Build
+        run: cargo build --features "serde"
+      - name: Run tests
+        run: cargo test -- --test-threads=1
+      - name: fmt
+        run: cargo fmt -v -- --check
+      - name: lint
+        run: cargo clippy --tests -- -D clippy::all
+      - name: doc
+        run: cargo doc


### PR DESCRIPTION
GitHub dropped support for `ubuntu-20.04` early 2025.
There was no runner to pick up the job when I was trying to trigger the release workflow.

This PR improves our CI pipeline by establishing a clear strategy for choosing runner images and configuring the release workflow to also run on pull requests. This will help us catch CI config issues earlier.