### PR TITLE
fix: release-npm workflow checkout and npm publish token

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -25,8 +25,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.version }}
       
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
SDK-2707

## Summary
Two bugs prevented the first npm publish from succeeding:

1. **Missing `npm/` directory at release tag** — the workflow checked out at `ref: ${{ inputs.version }}`, but the `npm/` directory was introduced after the `0.9.11` release tag. The workflow only needs scripts from the default branch (binaries are downloaded from the specified release), so the `ref` pin is removed.

2. **Missing `release` GitHub environment** — `npm publish --provenance` requires an npm token with publish access to `@icp-sdk`. This repo does not have the `release` environment set up yet, which is the organizational convention for trusted publishing to npm. The workflow fell back to a narrower-scoped repo-level token that returned 404 when trying to create new packages. Adding `environment: release` to the workflow job declares the dependency; the environment itself still needs to be created (see Prerequisites below).

## Prerequisites (action required before merging)
- [x] **InfraSec**: Set up the `release` environment in this repo's GitHub settings following the organizational convention for trusted publishing to npm.

## Test plan
- [x] Dispatch the workflow from this branch with version `0.9.11` after the `release` environment is set up, to verify the full publish succeeds end-to-end.
  - The release job succeeded: https://github.com/dfinity/ic-wasm/actions/runs/25738804985
  - The package was published on npmjs.org: https://www.npmjs.com/package/@icp-sdk/ic-wasm/v/0.9.11