### PR TITLE
fix: use assert_cmd cargo_bin_cmd! macro in tests (#101)

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,7 +16,11 @@ fn input(wasm: &str) -> PathBuf {
 
 /// An `ic-wasm` command reading the given input path.
 fn ic_wasm(input: impl AsRef<Path>) -> Command {
-    let mut cmd = Command::cargo_bin("ic-wasm").unwrap();
+    // `cargo_bin_cmd!` resolves the built binary via the `CARGO_BIN_EXE_ic-wasm`
+    // env var Cargo sets at compile time. The older `Command::cargo_bin` guessed
+    // the path from the test executable's location, which breaks under Cargo's
+    // custom `build-dir` (rust-lang/cargo#16147, rust-lang/cargo#15010).
+    let mut cmd = assert_cmd::cargo_bin_cmd!("ic-wasm");
     // Keep error output deterministic for exact stderr assertions: CI sets
     // `RUST_BACKTRACE=1`, which makes anyhow append a backtrace to stderr.
     cmd.env_remove("RUST_BACKTRACE")


### PR DESCRIPTION
Fixes #101.

## Problem

`tests/tests.rs` used `Command::cargo_bin("ic-wasm")`. In `assert_cmd` 2.2.2 that function reads `CARGO_BIN_EXE_ic-wasm` at **runtime** and, when it's absent, falls back to `legacy_cargo_bin` — a heuristic that guesses the binary path from the test executable's location. That heuristic breaks under Cargo's relocated `build-dir` ([rust-lang/cargo#16147](https://github.com/rust-lang/cargo/issues/16147), [rust-lang/cargo#15010](https://github.com/rust-lang/cargo/issues/15010)), as the issue author (the `assert_cmd` maintainer) notes.

It's a **latent** bug: no released Cargo relocates the *final* binary yet — `build-dir` currently only moves intermediate artifacts, and the runtime env var still short-circuits the fragile path — so today's tests pass. It would surface once a future Cargo makes the relocation apply to test/bin artifacts. Since the toolchain is pinned to `stable`, that would regress CI automatically the day such a Cargo ships.

## Fix

Switch to the maintainer-recommended macro:

```rust
let mut cmd = assert_cmd::cargo_bin_cmd!("ic-wasm");
```

`cargo_bin_cmd!` expands to `Command::new(Path::new(env!("CARGO_BIN_EXE_ic-wasm")))` — a **compile-time** `env!` read of the variable Cargo guarantees to set for integration tests. No runtime lookup, no fragile fallback. It returns an `assert_cmd::Command` directly, so the `.unwrap()` is gone too.

No dependency change: the macro has existed since `assert_cmd` 2.1.0 and `Cargo.toml` already allows `assert_cmd = "2"` (lockfile is 2.2.2).

## Verification

- `cargo test --test tests` → 8/8 pass
- `CARGO_BUILD_BUILD_DIR=<custom> cargo test --test tests` (the exact scenario from the issue) → 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)